### PR TITLE
Freeze the version of osmium-tool at v1.9.1.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y \
     libosmium2-dev
 
 WORKDIR /code
-RUN git clone https://github.com/osmcode/osmium-tool.git
+RUN git clone --branch "v1.9.1" --depth 1 https://github.com/osmcode/osmium-tool.git
 
 WORKDIR /code/osmium-tool/build
 RUN cmake ..


### PR DESCRIPTION
This is needed because newer versions won't build - the version of libosmium2-dev installed by the Ubuntu package manager is too old.